### PR TITLE
Update dependencies

### DIFF
--- a/docker/requirements.ci.txt
+++ b/docker/requirements.ci.txt
@@ -3,7 +3,7 @@ skl2onnx==1.13
 onnxruntime==1.13.1
 
 #
-scikit-learn==1.1.1  # <-- skl2onnx 1.13 has requirement scikit-learn<=1.1.1
+scikit-learn==1.1.1   # <-- skl2onnx 1.13 has requirement scikit-learn<=1.1.1
 pandas==1.5.2
 matplotlib==3.6.2
 

--- a/docker/requirements.ci.txt
+++ b/docker/requirements.ci.txt
@@ -1,24 +1,16 @@
-# Ray installs protobuf 3.18 (latest as of 9/2021), but ONNX install
-# instructions explicitly mention protobuf 3.16. Therefore we first
-# install protobuf 3.16.
-#
-# See,
-#  - https://github.com/onnx/onnx#official-python-packages
-#  - https://docs.microsoft.com/en-us/azure/azure-sql-edge/deploy-onnx
-protobuf==3.18.3
-onnx==1.11.0
-skl2onnx==1.11
-onnxruntime==1.11.0
+onnx==1.13.0
+skl2onnx==1.13
+onnxruntime==1.13.1
 
 #
-scikit-learn==1.1.1
-pandas==1.4.3
-matplotlib==3.5.2
+scikit-learn==1.1.1  # <-- skl2onnx 1.13 has requirement scikit-learn<=1.1.1
+pandas==1.5.2
+matplotlib==3.6.2
 
 # libraries for running unit and static tests on code
-pytest==6.2.5
-black==22.3.0
-mypy==0.931
+pytest==7.2.0
+black==22.12.0
+mypy==0.991
 
 #
 pynb-dag-runner-snapshot

--- a/workspace/mnist-demo-pipeline/mnist-demo-pipeline/reporting.py
+++ b/workspace/mnist-demo-pipeline/mnist-demo-pipeline/reporting.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 
 #
+from pynb_dag_runner import version_string
 from pynb_dag_runner.opentelemetry_helpers import Spans
 from pynb_dag_runner.opentelemetry_task_span_parser import parse_spans
 
@@ -50,6 +51,7 @@ def is_remote_run(spans: Spans) -> bool:
     } <= get_pipeline_attributes(spans).keys()
 
 
+print(f"--- demo pipeline reporting {version_string()} ---")
 print(f"  - input_otel_spans_json_file  : {args().input_otel_spans_json_file}")
 print(f"  - output_markdown_file        : {args().output_markdown_file}")
 


### PR DESCRIPTION
Update dependencies and test locally that demo pipeline works with Ray 2.20-based pynb-dag-runner.

- protobuffer constraints no longer needed
- reporting and pipeline driver scripts now print what version of `pynb_dag_runner` is being used